### PR TITLE
Add initial readthedocs configs

### DIFF
--- a/hip-python/.readthedocs.yaml
+++ b/hip-python/.readthedocs.yaml
@@ -9,10 +9,10 @@ build:
     python: "3.8"
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: hip-python/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
   install:
-  - requirements: docs/.sphinx/requirements.txt
+  - requirements: hip-python/docs/.sphinx/requirements.txt


### PR DESCRIPTION
Place the .readthedocs.yaml in the hip-python directory