### PR TITLE
Remove unsupported pdf build

### DIFF
--- a/hip-python/.readthedocs.yaml
+++ b/hip-python/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
 sphinx:
   configuration: hip-python/docs/conf.py
 
-formats: [htmlzip, pdf, epub]
+formats: [htmlzip]
 
 python:
   install:


### PR DESCRIPTION
to fix error with RTD build

![image](https://github.com/ROCmSoftwarePlatform/hip-python/assets/22262939/977924d3-5b09-4349-ac76-0fee08c570e7)