### PR TITLE
ci(build-and-publish.jf):  Adds an apt mirror selection option

### DIFF
--- a/ci/build-and-publish.jf
+++ b/ci/build-and-publish.jf
@@ -32,6 +32,7 @@ pipeline {
     parameters {
         editableChoice(
             choices: [
+                '6.1.0',
                 '6.0.0',
                 '5.7.1',
                 '5.7.0',

--- a/ci/build-and-publish.jf
+++ b/ci/build-and-publish.jf
@@ -67,6 +67,14 @@ pipeline {
             description: 'The main branch where the ci scripts, docs and other files imported by `init.sh` are located.',
             name: 'MAIN_BRANCH'
         )
+        editableChoice(
+            choices: [
+                "mirror.math.ucdavis.edu",
+                "archive.ubuntu.com",
+            ],
+            description: 'Use a different Ubuntu mirror; see https://launchpad.net/ubuntu/+archivemirrors. First is default.',
+            name: 'UBUNTU_APT_MIRROR'
+        )
     }
     stages {
         stage('clean-ws') {
@@ -76,9 +84,12 @@ pipeline {
         }
         stage('get-repo') {
             steps {
+                sh '''#!/usr/bin/env bash
+                sed -i "s,archive.ubuntu.com,${UBUNTU_APT_MIRROR},g" /etc/apt/sources.list
+                apt-get update && apt-get -y install git sudo
+                '''
                 // TODO Below `git branch: 'main' ...` can likely be removed via non-lightweight checkout
                 git branch: 'main', credentialsId: 'HIP_PYTHON_DEV', url: 'https://github.com/ROCmSoftwarePlatform/hip-python'
-                sh 'apt update && apt install -y git'
                 dir('.') {
                     withCredentials([
                         usernamePassword(credentialsId: 'HIP_PYTHON_DEV', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER'),


### PR DESCRIPTION
Allows to select a different apt mirror if the default Ubuntu one is too slow.

## Testing TODOs

* [x] Generate ROCm 6.1.0 release sources and test pypi packages with this branch.