### PR TITLE
Remove format to reduce build time

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
 sphinx:
   configuration: docs/conf.py
 
-formats: [htmlzip]
+formats: []
 
 python:
   install:


### PR DESCRIPTION
With htmlzip format, the build currently exceeds the build time limit. Remove it to reduce build time